### PR TITLE
[LC-888] Change python requires to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ deps = {
     ],
 }
 
-deps['dev'] = deps['lft'] + deps['app'] + deps['test']
+deps['app'] = deps['lft'] + deps['app']
+deps['dev'] = deps['test'] = deps['app'] + deps['test']
 install_requires = deps['lft']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ deps = {
         "ipython==7.9.0"
     ],
     'test': [
+        "mock==4.0.1",
         "pytest==4.6.3",
         "pytest-asyncio==0.10.0"
     ],
@@ -22,7 +23,7 @@ setup(
     version='0.1.0',
     description='Loopchain Fault Tolerance',
     author='ICON Foundation',
-    python_requires=">=3.8.0",
+    python_requires=">=3.7.0",
     install_requires=install_requires,
     extras_require=deps,
     license='Apache License 2.0',

--- a/tests/units/consensus/change_candidate_test.py
+++ b/tests/units/consensus/change_candidate_test.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from typing import Tuple
-from unittest.mock import MagicMock
+from mock import MagicMock
 from lft.app.data import DefaultDataFactory, DefaultData
 from lft.app.vote import DefaultVoteFactory
 from lft.app.epoch import RotateEpoch

--- a/tests/units/consensus/filter_message_test.py
+++ b/tests/units/consensus/filter_message_test.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 import pytest
 

--- a/tests/units/consensus/initialize_test.py
+++ b/tests/units/consensus/initialize_test.py
@@ -1,6 +1,6 @@
 import pytest
 import random
-from unittest.mock import MagicMock
+from mock import MagicMock
 from lft.app.data import DefaultDataFactory, DefaultData
 from lft.app.vote import DefaultVoteFactory, DefaultVote
 from lft.app.epoch import RotateEpoch

--- a/tests/units/consensus/mocks.py
+++ b/tests/units/consensus/mocks.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, AsyncMock
+from mock import MagicMock, AsyncMock
 
 from lft.consensus.epoch import Epoch
 from lft.consensus.round import Round

--- a/tests/units/consensus/setup_consensus.py
+++ b/tests/units/consensus/setup_consensus.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from mock import MagicMock
 from functools import partial
 
 from lft.app.data import DefaultData, DefaultDataFactory

--- a/tests/units/election/setup_election.py
+++ b/tests/units/election/setup_election.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from mock import MagicMock
 from typing import Tuple, List
 from lft.app.data import DefaultDataFactory, DefaultData
 from lft.app.vote import DefaultVoteFactory

--- a/tests/units/round/setup_items.py
+++ b/tests/units/round/setup_items.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock
+from mock import MagicMock
 from lft.app.data import DefaultDataFactory
 from lft.app.vote import DefaultVoteFactory
 from lft.app.epoch import RotateEpoch


### PR DESCRIPTION
- Replace 'unittest.mock' with 'mock' library to support Python 3.7