### PR TITLE
[LC-923] Fix verify_proposer interface

### DIFF
--- a/lft/consensus/epoch.py
+++ b/lft/consensus/epoch.py
@@ -50,7 +50,16 @@ class Epoch(Serializable):
         raise NotImplementedError
 
     @abstractmethod
-    def verify_proposer(self, proposer_id: bytes, round_num: int) -> bool:
+    def verify_proposer(self, proposer_id: bytes, round_num: int):
+        """
+
+        :param proposer_id:
+        :param round_num:
+        :raises:
+            InvalidProposer:
+            InvalidEpoch:
+            InvalidRound:
+        """
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
# Goal
- Remove type hint of `Epoch.verifiy_proposer`
- Let users know possible exceptions can be raised in it

# Reason
> LFT library do not use its return values at all. 
> LFT library catches its exception types.