### PR TITLE
[LC-977] Fix to choose previous voters instead of current voters.

### DIFF
--- a/lft/consensus/consensus.py
+++ b/lft/consensus/consensus.py
@@ -176,8 +176,8 @@ class Consensus(EventRegister):
 
     def _new_round(self, epoch_num: int, round_num: int, candidate_id: bytes):
         epoch = self._get_epoch(epoch_num)
-        election = Election(self._node_id, epoch, round_num, self._event_system,
-                            self._data_factory, self._vote_factory, self._data_pool, self._vote_pool)
+        election = Election(self._node_id, epoch.num, round_num, self._event_system,
+                            self._data_factory, self._vote_factory, self._epoch_pool, self._data_pool, self._vote_pool)
         new_round = Round(election, self._node_id, epoch, round_num,
                           self._event_system, self._data_factory, self._vote_factory)
         new_round.candidate_id = candidate_id

--- a/tests/units/election/setup_election.py
+++ b/tests/units/election/setup_election.py
@@ -5,6 +5,7 @@ from lft.app.vote import DefaultVoteFactory
 from lft.app.epoch import RotateEpoch
 from lft.consensus.messages.data import DataPool
 from lft.consensus.messages.vote import VotePool
+from lft.consensus.epoch import EpochPool
 from lft.consensus.election import Election
 from lft.event import EventSystem
 
@@ -32,7 +33,11 @@ async def setup_election(peer_num: int) -> Tuple[EventSystem, Election, List[byt
     )
     data_pool.add_data(genesis_data)
 
-    election = Election(TEST_NODE_ID, RotateEpoch(0, voters), genesis_data.round_num + 1,
-                        event_system, data_factory, vote_factory, data_pool, vote_pool)
+    epoch = RotateEpoch(0, voters)
+    epoch_pool = EpochPool()
+    epoch_pool.add_epoch(epoch)
+
+    election = Election(TEST_NODE_ID, epoch.num, genesis_data.round_num + 1,
+                        event_system, data_factory, vote_factory, epoch_pool, data_pool, vote_pool)
     election._candidate_id = CANDIDATE_ID
     return event_system, election, voters

--- a/tests/units/round/setup_items.py
+++ b/tests/units/round/setup_items.py
@@ -6,6 +6,7 @@ from lft.app.vote import DefaultVoteFactory
 from lft.app.epoch import RotateEpoch
 from lft.consensus.election import Election
 from lft.consensus.round import Round
+from lft.consensus.epoch import EpochPool
 from lft.consensus.messages.data import DataPool
 from lft.consensus.messages.vote import VotePool
 from lft.event import EventSystem
@@ -17,17 +18,21 @@ async def setup_items(voter_num: int, round_num: int):
     voter = voters[0]
 
     epoch = RotateEpoch(1, voters)
+    epoch_pool = EpochPool()
+    epoch_pool.add_epoch(epoch)
+
     event_system = MagicMock(EventSystem(use_priority=True))
 
     data_factory = DefaultDataFactory(voter)
     vote_factory = DefaultVoteFactory(voter)
 
     election = MagicMock(Election(voter,
-                                  epoch,
+                                  epoch.num,
                                   round_num,
                                   event_system,
                                   data_factory,
                                   vote_factory,
+                                  epoch_pool,
                                   DataPool(),
                                   VotePool()))
     round_ = Round(election,


### PR DESCRIPTION
The current block must contain previous votes whose voters are defined by previous epoch.